### PR TITLE
Fix: Application is not out-of-the-box deployable without XSUAA #6

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,5 +20,10 @@
   },
   "scripts": {
     "start": "cds-serve"
+  },
+  "cds": {
+    "requires": {
+      "auth": "mocked"
+    }
   }
 }


### PR DESCRIPTION
As part of the [Developing Applications on SAP BTP, Cloud Foundry runtime](https://learning.sap.com/learning-journeys/developing-applications-on-sap-btp-cloud-foundry-runtime) course, one of the exercises is to deploy this preconfigured application as shown [here](https://learning.sap.com/learning-journeys/developing-applications-on-sap-btp-cloud-foundry-runtime/deploying-your-first-application
). This fails out-of-the-box for the reasons mentioned in #6 which learners (including myself) are currently facing.

Fix credits: @corporatemax