### PR TITLE
use AI Resource group config in mta (required by SAP AI Core SDK

### DIFF
--- a/examples/ai-samples/ai-agent-demo/README.md
+++ b/examples/ai-samples/ai-agent-demo/README.md
@@ -102,7 +102,7 @@ uv pip compile pyproject.toml -o requirements.txt
 
 **Steps to configure**
 
-1. **Determine your region and route**:
+1. **Determine your region and route**
    ```bash
    # Check your CF API endpoint to identify your region
    cf api
@@ -111,7 +111,7 @@ uv pip compile pyproject.toml -o requirements.txt
    # https://api.cf.us10.hana.ondemand.com (US - East)
    ```
 
-2. **Update `xs-security.json`** with your specific route:
+2. **Update `xs-security.json`** with your specific route
 
    Edit `deploy/xs-security.json`:
 
@@ -121,7 +121,7 @@ uv pip compile pyproject.toml -o requirements.txt
    ]
    ```
 
-   **Region examples**:
+   **Region examples**
    - EU (Frankfurt): `eu12`
    - US (East): `us10`
    - Asia Pacific (Singapore): `ap21`

--- a/examples/ai-samples/ai-agent-demo/deploy/mta.yaml
+++ b/examples/ai-samples/ai-agent-demo/deploy/mta.yaml
@@ -46,6 +46,7 @@ modules:
       buildpack: python_buildpack
     properties:
       PYTHONUNBUFFERED: "1"
+      AICORE_RESOURCE_GROUP: "default" # Replace with your AI Core resource group if different
     provides:
       - name: tools-chat-backend
         properties:


### PR DESCRIPTION
## Problem

AI-Resource-Group was not provided to the SAP AI Core Configuration
```
 ai_api_client_sdk.exception.AIAPIInvalidRequestException: Failed to get /deployments: Invalid Request, Missing header parameter 'AI-Resource-Group'
```
## Solution

Provide the `AI-Resource-Group` in mta.yaml